### PR TITLE
Enlarge the top number of \newXeTeXintercharclass for XeTeX 0.99994. 

### DIFF
--- a/xetex.ini
+++ b/xetex.ini
@@ -80,7 +80,7 @@
   \errmessage{No room for a new #3}%
  \fi}
 \def\newXeTeXintercharclass{%
- \xe@alloc@\xe@alloc@intercharclass\XeTeXcharclass\chardef\@cclv}
+ \xe@alloc@\xe@alloc@intercharclass\XeTeXcharclass\chardef\xe@charclass@boundary}
 
 % The limit for character class has been enlarged from 256 to 4096 since XeTeX 0.99994.
 % So the boundary of character class is changed from 255 to 4095.

--- a/xetex.ini
+++ b/xetex.ini
@@ -34,7 +34,7 @@
   \global\XeTeXinterchartoks 1 1 = {\xtxHanGlue}
   \global\XeTeXinterchartoks 1 2 = {\xtxHanGlue}
   \global\XeTeXinterchartoks 1 3 = {\nobreak\xtxHanGlue}
-  
+
   \global\XeTeXinterchartoks 2 1 = {\nobreak\xtxHanGlue}
   \global\XeTeXinterchartoks 2 2 = {\nobreak\xtxHanGlue}
   \global\XeTeXinterchartoks 2 3 = {\xtxHanGlue}
@@ -66,7 +66,7 @@
 \let\s@vef@nt=\und@fined
 
 %
-% Allocator for \XeTeXintercharclass values, from Enrico Gregorio 
+% Allocator for \XeTeXintercharclass values, from Enrico Gregorio
 %
 \newcount\xe@alloc@intercharclass % allocates intercharclass
 \xe@alloc@intercharclass=\thr@@   % from 4 (1,2 and 3 are used by CJK, AFAIK)
@@ -80,7 +80,7 @@
   \errmessage{No room for a new #3}%
  \fi}
 \def\newXeTeXintercharclass{%
- \xe@alloc@\xe@alloc@intercharclass\XeTeXintercharclass\chardef\@cclv} % At most 254
+ \xe@alloc@\xe@alloc@intercharclass\XeTeXcharclass\chardef\@cclv} % At most 254
 
 % Primitives in pdfTeX and LuaTeX, we'll just use macros here.
 % Since we are generating a whatsit, not 100% compatible,

--- a/xetex.ini
+++ b/xetex.ini
@@ -80,7 +80,17 @@
   \errmessage{No room for a new #3}%
  \fi}
 \def\newXeTeXintercharclass{%
- \xe@alloc@\xe@alloc@intercharclass\XeTeXcharclass\chardef\@cclv} % At most 254
+ \xe@alloc@\xe@alloc@intercharclass\XeTeXcharclass\chardef\@cclv}
+
+% The limit for character class has been enlarged from 256 to 4096 since XeTeX 0.99994.
+% So the boundary of character class is changed from 255 to 4095.
+% Primitive \XeTeXinterwordspaceshaping is introduced by XeTeX 0.99994.
+% We can use it as a flag.
+\ifx\XeTeXinterwordspaceshaping\und@fined
+  \chardef\xe@charclass@boundary=\@cclv
+\else
+  \chardef\xe@charclass@boundary=4095 %
+\fi
 
 % Primitives in pdfTeX and LuaTeX, we'll just use macros here.
 % Since we are generating a whatsit, not 100% compatible,


### PR DESCRIPTION
See http://tug.org/pipermail/xetex/2016-February/026363.html.

LaTeX2e's `\newXeTeXintercharclass` should be adjusted too.